### PR TITLE
Improve using settings in inspection mode

### DIFF
--- a/compose-remember-setting/build.gradle.kts
+++ b/compose-remember-setting/build.gradle.kts
@@ -42,6 +42,7 @@ kotlin {
             api(libs.multiplatformSettings.core)
             api(libs.multiplatformSettings.coroutines)
             api(compose.runtime)
+            implementation(compose.ui)
             implementation(libs.multiplatformSettings.makeObservable)
             implementation(libs.multiplatformSettings.noarg)
             implementation(libs.multiplatformSettings.test)

--- a/compose-remember-setting/src/commonMain/kotlin/ComposeRememberSettingConfig.kt
+++ b/compose-remember-setting/src/commonMain/kotlin/ComposeRememberSettingConfig.kt
@@ -1,19 +1,11 @@
 package dev.burnoo.compose.remembersetting
 
-import androidx.compose.runtime.compositionLocalOf
 import com.russhwolf.settings.ExperimentalSettingsApi
 import com.russhwolf.settings.MapSettings
 import com.russhwolf.settings.ObservableSettings
 import com.russhwolf.settings.Settings
 import com.russhwolf.settings.observable.makeObservable
 import kotlinx.coroutines.CoroutineDispatcher
-
-@OptIn(ExperimentalSettingsApi::class)
-val LocalComposeRememberSettingConfig = compositionLocalOf {
-    val observableSettings = runCatching { Settings().makeObservable() }
-        .getOrElse { MapSettings() } // Fallback for Previews
-    ComposeRememberSettingConfig(observableSettings)
-}
 
 @OptIn(ExperimentalSettingsApi::class)
 data class ComposeRememberSettingConfig(

--- a/compose-remember-setting/src/commonMain/kotlin/LocalComposeRememberSettingConfig.kt
+++ b/compose-remember-setting/src/commonMain/kotlin/LocalComposeRememberSettingConfig.kt
@@ -1,0 +1,39 @@
+package dev.burnoo.compose.remembersetting
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.platform.LocalInspectionMode
+import com.russhwolf.settings.ExperimentalSettingsApi
+import com.russhwolf.settings.MapSettings
+import com.russhwolf.settings.Settings
+import com.russhwolf.settings.observable.makeObservable
+
+/**
+ * CompositionLocal to provide [ComposeRememberSettingConfig] to all children.
+ * By default uses [LocalDefaultComposeRememberSettingConfig] in runtime and
+ * [LocalPreviewComposeRememberSettingConfig] in inspection mode (e.g. preview).
+ * To get non-null current value use [ProvidableCompositionLocal.requireCurrent].
+ */
+val LocalComposeRememberSettingConfig = compositionLocalOf<ComposeRememberSettingConfig?> { null }
+
+@Composable
+fun ProvidableCompositionLocal<ComposeRememberSettingConfig?>.requireCurrent(): ComposeRememberSettingConfig {
+    val isLocalInspectionMode = LocalInspectionMode.current
+    val localComposeRememberSettingConfig = current
+    return when {
+        localComposeRememberSettingConfig != null -> localComposeRememberSettingConfig
+        isLocalInspectionMode -> LocalPreviewComposeRememberSettingConfig.current
+        else -> LocalDefaultComposeRememberSettingConfig.current
+    }
+}
+
+@OptIn(ExperimentalSettingsApi::class)
+private val LocalDefaultComposeRememberSettingConfig = staticCompositionLocalOf {
+    ComposeRememberSettingConfig(observableSettings = Settings().makeObservable())
+}
+
+private val LocalPreviewComposeRememberSettingConfig = staticCompositionLocalOf {
+    ComposeRememberSettingConfig(observableSettings = MapSettings())
+}

--- a/compose-remember-setting/src/commonMain/kotlin/internal/rememberSetting.kt
+++ b/compose-remember-setting/src/commonMain/kotlin/internal/rememberSetting.kt
@@ -9,11 +9,12 @@ import com.russhwolf.settings.coroutines.toFlowSettings
 import com.russhwolf.settings.get
 import com.russhwolf.settings.set
 import dev.burnoo.compose.remembersetting.LocalComposeRememberSettingConfig
+import dev.burnoo.compose.remembersetting.requireCurrent
 
 @OptIn(ExperimentalSettingsApi::class)
 @Composable
 internal inline fun <reified T> rememberSetting(key: String, defaultValue: T): MutableState<T> {
-    val (observableSettings, flowSettingsDispatcher) = LocalComposeRememberSettingConfig.current
+    val (observableSettings, flowSettingsDispatcher) = LocalComposeRememberSettingConfig.requireCurrent()
     val coroutineScope = rememberCoroutineScope()
     return remember(key) {
         val flowSettings = if (flowSettingsDispatcher == null) {

--- a/compose-remember-setting/src/commonTest/kotlin/LocalComposeRememberSettingConfigTest.kt
+++ b/compose-remember-setting/src/commonTest/kotlin/LocalComposeRememberSettingConfigTest.kt
@@ -1,0 +1,58 @@
+package dev.burnoo.compose.remembersetting
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.runComposeUiTest
+import com.russhwolf.settings.MapSettings
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.kotest.matchers.types.shouldBeSameInstanceAs
+import io.kotest.matchers.types.shouldNotBeInstanceOf
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class LocalComposeRememberSettingConfigTest {
+
+    @Test
+    fun shouldUseMapSettingsInPreviewInPreview() = runComposeUiTest {
+        setContent {
+            CompositionLocalProvider(LocalInspectionMode provides true) {
+                val config = LocalComposeRememberSettingConfig.requireCurrent()
+                LaunchedEffect(Unit) {
+                    config.observableSettings.shouldBeInstanceOf<MapSettings>()
+                }
+            }
+        }
+    }
+
+    @Test
+    fun shouldNotUseMapSettingsInPreviewByDefault() = runComposeUiTest {
+        setContent {
+            CompositionLocalProvider(LocalInspectionMode provides false) {
+                val config = LocalComposeRememberSettingConfig.requireCurrent()
+                LaunchedEffect(Unit) {
+                    config.observableSettings.shouldNotBeInstanceOf<MapSettings>()
+                }
+            }
+        }
+    }
+
+    @Test
+    fun shouldUseProvidedSettings() = runComposeUiTest {
+        val providedSettings = MapSettings()
+        setContent {
+            CompositionLocalProvider(
+                LocalInspectionMode provides false,
+                LocalComposeRememberSettingConfig provides ComposeRememberSettingConfig(
+                    observableSettings = providedSettings,
+                ),
+            ) {
+                val config = LocalComposeRememberSettingConfig.requireCurrent()
+                LaunchedEffect(Unit) {
+                    config.observableSettings shouldBeSameInstanceAs providedSettings
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Previously library was trying to create default Settings, and after crash MapSettings was created. This mechanism was replaced by manually detecting if the run is an inspection mode.

Also added `requireCurrent()` function to allow user to get the current Settings as previously