### PR TITLE
Fix Android example not running

### DIFF
--- a/example/composeApp/src/androidMain/kotlin/dev/burnoo/compose/remembersetting/example/MainActivity.kt
+++ b/example/composeApp/src/androidMain/kotlin/dev/burnoo/compose/remembersetting/example/MainActivity.kt
@@ -1,4 +1,4 @@
-package dev.burnoo.compose.remembersetting
+package dev.burnoo.compose.remembersetting.example
 
 import App
 import ComposeRememberSettingPreview


### PR DESCRIPTION
It was placed in incorrect package previously, effectively breaking Android example. Moving `MainActivity` to `.example` package fixes the issue